### PR TITLE
Add Void Linux to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ sudo snap install bitwise
 #### Arch
 You can use the AUR repository: https://aur.archlinux.org/packages/bitwise/
 
+#### Void
+_bitwise_ is in the default repository, so just type:
+`
+sudo xbps-install -S bitwise
+`
+
 ### macOS
 
 #### MacPorts


### PR DESCRIPTION
*bitwise* is in the official libre 64-bit repo and [has a maintainer](https://github.com/void-linux/void-packages/blob/master/srcpkgs/bitwise/template#L9)