### PR TITLE
Add support for leading 0 on binary numbers

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -131,6 +131,11 @@ int binary_scanf(const char *buf, uint64_t *val)
 {
 	uint64_t value = 0;
 
+	/* Skip the leading 0 */
+	if (buf[0] == '0') {
+		buf++;
+	}
+
 	/* Skip the leading b */
 	buf++;
 
@@ -192,7 +197,9 @@ int parse_input(const char *input, uint64_t *val)
 	if (tolower(input[0]) == 'b')
 		base = 2;
 	else if (input[0] == '0')
-		if (input[1] == 'x' || input[1] == 'X')
+		if (tolower(input[1] == 'b'))
+			base = 2;
+		else if (input[1] == 'x' || input[1] == 'X')
 			base = 16;
 		else
 			base = 8;

--- a/tests/test-shunting-yard.c
+++ b/tests/test-shunting-yard.c
@@ -26,6 +26,8 @@ static void test_addition()
 	ASSERT_RESULT("0x2+0x2", 0x4);
 	ASSERT_RESULT("0x2 + 0x2", 0x4);
 	ASSERT_RESULT("0x2 + b101", 7);
+	ASSERT_RESULT("0x2 + 0b101", 7);
+	ASSERT_RESULT("0b101 + 0x2", 7);
 	ASSERT_RESULT("2  +  2", 4);
 	ASSERT_RESULT("2+2.", 4);
 	ASSERT_RESULT("3 + (5 + 1 + (2 + 2))", 13);


### PR DESCRIPTION
Languages such as python and C support writing binary numbers with a leading zero: `0b1000`. Bitwise does not currently support this, but I think it is something that should be. For one, I thought bitwise had a bug when it interpreted `0b1000` as simply `0`. 

This merge request implements support for this. Thanks to `0x` already being supported, it was a minor change and I don't expected it to break anything. Additionally, I added two new tests; one for making sure that the result is same when using `b` and `b`, and another one for making sure that there would not be any issues putting `0b` in the beginning of the calculation. 

Thank you for a great little utility :) 