### PR TITLE
Add nix installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ brew install bitwise
 ### Windows
 NCurses doesn't support windows. You can use the windows subsystem for Linux as a workaround.
 
+### Nix
+```
+nix-env -i bitwise
+```
+
 ### Building from source
 
 #### Prerequisites


### PR DESCRIPTION
I recently added bitwise to [nixpkgs](https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/misc/bitwise) so I added it as an installation option in the README. I just put it in its own section after Windows since it works on multiple OSes, but maybe you have a different idea for where it should go?