### PR TITLE
Fix -Werror=format-security errors with mvwprintw()

### DIFF
--- a/src/interactive.c
+++ b/src/interactive.c
@@ -114,7 +114,7 @@ void update_history_win(void)
 				break;
 			}
 
-		mvwprintw(history_win, j, 2, history[history_pos - i].line);
+		mvwprintw(history_win, j, 2, "%s", history[history_pos - i].line);
 	}
 
 	if (g_has_color)


### PR DESCRIPTION
Here a non-constant is used as a format string which
compiler complains about. Fix by using "%s" as format.

Signed-off-by: Khem Raj <raj.khem@gmail.com>