### PR TITLE
ipv4: treat 0xffffffff as a valid ipv4 address

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -66,7 +66,7 @@ int print_conversions(uint64_t val, bool si)
 	if (g_width < 64)
 		printf("%sRadix64: %s%s\n", color_green, color_blue, l64a(val));
 
-	if (val >= UINT_MAX) {
+	if (val > UINT_MAX) {
 		printf("%sIPv4: %s%s\n", color_green, color_blue, "Value too big to be a valid IPv4 address");
 	} else {
 		ip_addr.s_addr = val;


### PR DESCRIPTION
In print_conversions() all values >= 0xffffffff are treated as invalid
ipv4 addresses. Since 255.255.255.255 is a valid ipv4 address change
this to just filter out values > 0xffffffff.

Signed-off-by: Danilo Krummrich <danilokrummrich@dk-develop.de>