### PR TITLE
Add Fedora Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ _bitwise_ is in the default repository, so just type:
 sudo xbps-install -S bitwise
 `
 
+#### Fedora Linux
+
+bitwise is available in the [official repository](https://src.fedoraproject.org/rpms/bitwise)
+
+```
+sudo dnf install bitwise
+```
+
 #### Buildroot / Yocto
 Bitwise is available both in Buildroot and in Yocto, please refer to the documentation on how to add those to your target image.
 


### PR DESCRIPTION
I'm maintaining bitwise for Fedora Linux. The package is currently only available for Fedora Linux 36 and Rawhide. For Fedora Linux 35 and 37 it's [in testing](https://bodhi.fedoraproject.org/updates/?search=bitwise).

See https://src.fedoraproject.org/rpms/bitwise.

Closes #4 